### PR TITLE
Allow extra files on 10.5

### DIFF
--- a/index.php
+++ b/index.php
@@ -476,7 +476,10 @@ class Updater {
 
 		$fp = fopen($storageLocation . basename($response['url']), 'w+');
 		$ch = curl_init($response['url']);
-		curl_setopt($ch, CURLOPT_FILE, $fp);
+		curl_setopt_array($ch, [
+			CURLOPT_FILE => $fp,
+			CURLOPT_USERAGENT => 'Nextcloud Updater',
+		]);
 		if(curl_exec($ch) === false) {
 			throw new \Exception('Curl error: ' . curl_error($ch));
 		}

--- a/index.php
+++ b/index.php
@@ -241,6 +241,25 @@ class Updater {
 	}
 
 	/**
+	 * Returns app directories specified in config.php
+	 *
+	 * @return array
+	 */
+	private function getAppDirectories() {
+		$expected = [];
+		if($appsPaths = $this->getConfigOption('apps_paths')) {
+			foreach ($appsPaths as $appsPath) {
+				$parentDir = realpath($this->baseDir . '/../');
+				$appDir = basename($appsPath['path']);
+				if(strpos($appsPath['path'], $parentDir) === 0 && $appDir !== 'apps') {
+					$expected[] = $appDir;
+				}
+			}
+		}
+		return $expected;
+	}
+
+	/**
 	 * Gets the recursive directory iterator over the Nextcloud folder
 	 *
 	 * @param string $folder
@@ -763,6 +782,8 @@ EOF;
 			'apps',
 			'updater',
 		];
+
+		$excludedElements = array_merge($excludedElements, $this->getAppDirectories());
 		/**
 		 * @var string $path
 		 * @var \SplFileInfo $fileInfo

--- a/index.php
+++ b/index.php
@@ -740,7 +740,7 @@ EOF;
 		}
 		// Delete shipped apps
 		$shippedApps = json_decode(file_get_contents($shippedAppsFile), true);
-		$shippedApps['shippedApps'][] = 'example-theme';
+		$shippedApps['shippedApps'][] = 'example-theme';
 		foreach($shippedApps['shippedApps'] as $app) {
 			$this->recursiveDelete($this->baseDir . '/../apps/' . $app);
 		}

--- a/index.php
+++ b/index.php
@@ -203,7 +203,9 @@ class Updater {
 			'..',
 			// Folders
 			'3rdparty',
+			'ocm-provider',
 			'apps',
+			'apps-external',
 			'config',
 			'core',
 			'data',
@@ -232,6 +234,7 @@ class Updater {
 			'CHANGELOG.md',
 			'COPYING',
 			'COPYING-AGPL',
+			'README.md',
 			'occ',
 			'db_structure.xml',
 		];

--- a/index.php
+++ b/index.php
@@ -259,6 +259,58 @@ class Updater {
 		return $expected;
 	}
 
+	private function getOwnCloudApps() {
+		return [
+		  'activity',
+		  'federatedfilesharing',
+		  'files_pdfviewer',
+		  'oauth2',
+		  'updatenotification',
+		  'admin_audit',
+		  'federation',
+		  'files_sharing',
+		  'password_policy',
+		  'user_external',
+		  'announcementcenter',
+		  'files',
+		  'files_texteditor',
+		  'provisioning_api',
+		  'user_ldap',
+		  'comments',
+		  'files_antivirus',
+		  'files_trashbin',
+		  'ransomware_protection',
+		  'user_shibboleth',
+		  'configreport',
+		  'files_classifier',
+		  'files_versions',
+		  'sharepoint',
+		  'windows_network_drive',
+		  'customgroups',
+		  'files_external',
+		  'firewall',
+		  'systemtags',
+		  'wopi',
+		  'dav',
+		  'files_external_dropbox',
+		  'firstrunwizard',
+		  'systemtags_management',
+		  'workflow',
+		  'encryption',
+		  'files_external_ftp',
+		  'guests',
+		  'templateeditor',
+		  'enterprise_key',
+		  'files_ldap_home',
+		  'market',
+		  'theme-enterprise',
+		  'external',
+		  'files_mediaviewer',
+		  'notifications',
+		  'twofactor_totp',
+		];
+	}
+
 	/**
 	 * Gets the recursive directory iterator over the Nextcloud folder
 	 *
@@ -740,6 +792,7 @@ EOF;
 		}
 		// Delete shipped apps
 		$shippedApps = json_decode(file_get_contents($shippedAppsFile), true);
+		$shippedApps['shippedApps'] = array_merge($shippedApps['shippedApps'], $this->getOwnCloudApps());
 		$shippedApps['shippedApps'][] = 'example-theme';
 		foreach($shippedApps['shippedApps'] as $app) {
 			$this->recursiveDelete($this->baseDir . '/../apps/' . $app);


### PR DESCRIPTION
Should make the web based migrator work together with an update of the update server hosted under https://updates.nextcloud.org/owncloud-migration/ 

- [x] Do not remove new apps-external directory that oC creates by default now
- [x] Fix too many requests response when downloading
- [x] Try to see if steps from https://nextcloud.com/migration/ still apply
- [ ] The update server would need to deliver 20.0.4 if the oC release is 10.5.x.x. @rullzer I could prepare a PR but I cannot find the code :wink: 

## Once merged
- [ ] Deploy to the download server at https://download.nextcloud.com/server/installer/migrator/index.php


Tested with the following additional patch:

```diff
diff --git a/index.php b/index.php
index d07d697..caf602a 100644
--- a/index.php
+++ b/index.php
@@ -409,6 +409,22 @@ class Updater {
         * @throws \Exception
         */
        private function getUpdateServerResponse() {
+               $response = [
+    'version' => '20.0.4.0',
+    'versionstring' => 'Nextcloud 20.0.4',
+       'url' => 'https://download.nextcloud.com/server/releases/nextcloud-20.0.4.zip',
+    'web' => 'https://docs.nextcloud.com/server/20/admin_manual/maintenance/upgrade.html',
+    'changes' => 'https://updates.nextcloud.com/changelog_server/?version=20.0.4',
+    'autoupdater' => 1,
+    'eol' => 0,
+    'signature' => 'NGnbpWWpZWcju26Av57gJd1cHusErTGHnt+r1cwPibd/MH6df9eb8xJhXcHeLSMt
+QI88IcZyX7Gavl5i5pB/zOANhOrgDTCaRokrfICFaL8ZhFHF1yK7oOTKhB3U3jQu
+sSdjxAg3azNcPXtAIJtEED38YnQFwHOIWeAaWAHvBzIxgG6fJh/iRsYM0+JsabBH
+LF55NkWIfsVvWS7ZpmAbIPWbh3t9DTdnQBdhXtIyyp+WxNtRuZP6bsIwoOs4HDgc
+oKV5Q9OpZ+a5p95jJUuEkOyqgzE7pyqQj/LZ990pBzKlgq3eKoIIFgZK3I/hOZXC
+zAQ3mXtrijNy/j9sloE03w=='
+       ];
+return $response;
                $this->silentLog('[info] getUpdateServerResponse()');
 
                $updaterServer = 'https://updates.nextcloud.org/owncloud-migration/';
```